### PR TITLE
Player TextDraw font style image

### DIFF
--- a/docs/scripting/functions/PlayerTextDrawFont.md
+++ b/docs/scripting/functions/PlayerTextDrawFont.md
@@ -19,9 +19,11 @@ Change the font of a player-textdraw.
 | text     | The ID of the player-textdraw to change the font of                                                                                       |
 | font     | There are four font styles as shown below. A font value greater than 3 does not display, and anything greater than 16 crashes the client. |
 
-Available Fonts:
+## Setting the font
 
-|
+There are 4 fonts available for textdraw text:
+
+![Image:320px-Textdraw_map.png](/images/textdraws/Textdraw_font_styles.png)
 
 ## Returns
 


### PR DESCRIPTION
# PlayerTextDrawFont

I added a image displaying the font styles available.

## Changes
```
## Setting the font

There are 4 fonts available for textdraw text:

![Image:320px-Textdraw_map.png](/images/textdraws/Textdraw_font_styles.png)
```

## Preview

## Setting the font

There are 4 fonts available for textdraw text:

![Image:320px-Textdraw_map.png](/images/textdraws/Textdraw_font_styles.png)